### PR TITLE
Remove on.pull_request.paths

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,8 +2,6 @@ name: Actionlint
 
 on:
   pull_request:
-    paths: 
-      - .github/workflows/**
 
 jobs:
   actionlint:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Github actions and reusable workflows for [shishifubing][url-owner] repositories
 
 </div>
 
+## Required workflows
+
+### [actionlint]
+
+- Lint github workflows
+
+Uses https://github.com/rhysd/actionlint
+
 ## Reusable workflows
 
 ### [tag]
@@ -68,6 +76,7 @@ jobs:
 
 [terraform]: ./actions/terraform/action.yml
 [tag]: ./.github/workflows/tag.yml
+[actionlint]: ./.github/workflows/actionlint.yml
 
 <!-- project links -->
 


### PR DESCRIPTION
Github expects the status from the required workflow, but the workflow doesn't run because of the rules

As a result, a PR cannot be merged

![image](https://user-images.githubusercontent.com/97828377/221361968-ad0f9a68-b8ab-4122-a06f-a86f89ed661a.png)
