### PR TITLE
Remove 'skip ci' from commit message

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -43,7 +43,7 @@ jobs:
           author: ${{ steps.import_gpg.outputs.name }} <${{ steps.import_gpg.outputs.email }}>
           committer: ${{ steps.import_gpg.outputs.name }} <${{ steps.import_gpg.outputs.email }}>
           add-paths: CHANGELOG.md
-          title: Add ${{ github.event.release.tag_name }} to CHANGELOG.md [skip ci]
+          title: Add ${{ github.event.release.tag_name }} to CHANGELOG.md
           body: This PR was automatically generated in ${{ env.JOB_URL }}
           labels: chore, repo, size/m
           signoff: true

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -49,7 +49,7 @@ jobs:
           signoff: true
           branch: chore/changelog/add-version-${{ github.event.release.tag_name }}
           commit-message: |
-            chore(changelog): add ${{ github.event.release.tag_name }} [skip ci]
+            chore(changelog): add ${{ github.event.release.tag_name }}
 
             Job-url: ${{ env.JOB_URL }}
 


### PR DESCRIPTION
If CI is skipped, required workflows will not run. In that case the MR cannot be merged